### PR TITLE
angular-io-quickstart to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: angular-io-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5
 - name: eks-demo
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4


### PR DESCRIPTION
Promote angular-io-quickstart to version 0.0.5