### PR TITLE
golang-web to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 2.3.82
 - name: golang-web
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote golang-web to version 0.0.2