### PR TITLE
golang-web to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 2.3.82
 - name: golang-web
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5


### PR DESCRIPTION
Promote golang-web to version 0.0.5