### PR TITLE
golang-template-http to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 2.3.82
 - name: golang-template-http
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9
 - name: golang-web
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7


### PR DESCRIPTION
Promote golang-template-http to version 0.0.9