### PR TITLE
golang-web to 0.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,4 +18,4 @@ dependencies:
   version: 0.0.12
 - name: golang-web
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.8


### PR DESCRIPTION
Promote golang-web to version 0.0.8