### PR TITLE
golang-template to 0.0.27

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 2.3.82
 - name: golang-template
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.25
+  version: 0.0.27
 - name: golang-template-http
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.12


### PR DESCRIPTION
Promote golang-template to version 0.0.27