### PR TITLE
markupkit-render-comparer to 0.0.18

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -22,3 +22,6 @@ dependencies:
 - name: golang-web
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.8
+- name: markupkit-render-comparer
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.18


### PR DESCRIPTION
Promote markupkit-render-comparer to version 0.0.18