### PR TITLE
markupkit-render-comparer to 0.0.29

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,4 +24,4 @@ dependencies:
   version: 0.0.8
 - name: markupkit-render-comparer
   repository: http://jenkins-x-chartmuseum:8080
-  version: ">=0.0.23"
+  version: 0.0.29


### PR DESCRIPTION
Promote markupkit-render-comparer to version 0.0.29