### PR TITLE
markupkit-render-comparer to 0.0.64

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,4 +27,4 @@ dependencies:
   version: 0.0.8
 - name: markupkit-render-comparer
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.63
+  version: 0.0.64


### PR DESCRIPTION
Promote markupkit-render-comparer to version 0.0.64