### PR TITLE
markupkit-render-comparer to 0.0.66

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 0.0.8
 - name: markupkit-render-comparer
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.65
+  version: 0.0.66
 - name: transformer
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.49


### PR DESCRIPTION
Promote markupkit-render-comparer to version 0.0.66